### PR TITLE
Switch Actions to use abstract classes instead of an enum

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/Instructions.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/Instructions.java
@@ -4,6 +4,7 @@ import com.qualcomm.robotcore.util.ElapsedTime;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.teamcode.autonomous.actions.Actions;
+import org.firstinspires.ftc.teamcode.autonomous.actions.SpinCarouselAction;
 import org.firstinspires.ftc.teamcode.autonomous.hardware.Hardware;
 import org.firstinspires.ftc.teamcode.autonomous.localization.Localization;
 import org.firstinspires.ftc.teamcode.autonomous.localization.Position;
@@ -32,7 +33,7 @@ public class Instructions {
     {
         actions = new Actions(hardware, localization);
 
-        actions.addTask(Actions.Action.SPIN_CAROUSEL, 1);
+        actions.addTask(new SpinCarouselAction(1));
     }
 
     //Enter initial navigation waypoints here.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/actions/Action.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/actions/Action.java
@@ -1,0 +1,17 @@
+package org.firstinspires.ftc.teamcode.autonomous.actions;
+
+import org.firstinspires.ftc.teamcode.autonomous.hardware.Hardware;
+import org.firstinspires.ftc.teamcode.autonomous.localization.Localization;
+
+public abstract class Action {
+
+    public final int index;
+
+    public Action(int index)
+    {
+        this.index = index;
+    }
+
+    public abstract void execute(Hardware hardware, Localization localization);
+
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/actions/Actions.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/actions/Actions.java
@@ -7,65 +7,30 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Actions {
-    private final Hardware _hardware;
-    private List<ActionTask> _actions;
-    private Localization _localization;
+    private final List<Action> actions = new ArrayList<>();
+    private final Hardware hardware;
+    private final Localization localization;
 
     public Actions(Hardware hardware, Localization localization)
     {
-        _localization = localization;
-        _hardware = hardware;
-        _actions = new ArrayList<>();
+        this.hardware = hardware;
+        this.localization = localization;
     }
 
-    public void addTask(Action action, int index)
+    public void addTask(Action action)
     {
-        _actions.add(new ActionTask(action, index));
+        actions.add(action);
     }
 
-    //Checks to see if there exists a task on a certain waypoint, if yes, execute that task. Preserves the privacy of the _actions list.
+    // Executes the task at the waypoint with a given index
     public void executeTask(int index)
     {
-        for (ActionTask task : _actions)
-            if (task.index == index)
-            {
-                switch (task.action)
-                {
-                    case SPIN_CAROUSEL:
-                        spinCarousel();
-                        return;
-                    case PLACE_CUBE:
-                        placeCube();
-                        return;
-                }
+        for (Action task : actions) {
+            if (task.index == index) {
+                task.execute(hardware, localization);
+                return;
             }
-    }
-
-    private void spinCarousel()
-    {
-        _hardware.carouselMotor.setTargetPosition(_hardware.carouselMotor.getCurrentPosition() + 1000); //Spin 1000 ticks. We don't care about the exact position, so we'll just add it to our current tick count.
-        _hardware.carouselMotor.setPower(0.4);
-    }
-
-    private void placeCube()
-    {
-
-    }
-
-    public enum Action
-    {
-        SPIN_CAROUSEL, PLACE_CUBE;
-    }
-
-    private class ActionTask
-    {
-        public ActionTask(Action action, int index)
-        {
-            this.action = action;
-            this.index = index;
         }
-
-        public Action action; //Specifies the action we want to carry out.
-        public Integer index; //Specifies which waypoint we want to execute task on.
     }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/actions/SpinCarouselAction.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/autonomous/actions/SpinCarouselAction.java
@@ -1,0 +1,20 @@
+package org.firstinspires.ftc.teamcode.autonomous.actions;
+
+import org.firstinspires.ftc.teamcode.autonomous.hardware.Hardware;
+import org.firstinspires.ftc.teamcode.autonomous.localization.Localization;
+
+public class SpinCarouselAction extends Action {
+
+    public SpinCarouselAction(int index)
+    {
+        super(index);
+    }
+
+    @Override
+    public void execute(Hardware hardware, Localization localization)
+    {
+        hardware.carouselMotor.setTargetPosition(hardware.carouselMotor.getCurrentPosition() + 1000); //Spin 1000 ticks. We don't care about the exact position, so we'll just add it to our current tick count.
+        hardware.carouselMotor.setPower(0.4);
+    }
+
+}


### PR DESCRIPTION
Helps with separation of concerns with actions and generally makes code a lot cleaner. This also allows actions to take specific parameters, if needed.